### PR TITLE
Fix typo in README and import error

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ OSRL uses the `WandbLogger` in [FSRL](https://github.com/liuzuxin/FSRL) and [Pyr
 For example, to train the `bcql` method, simply run by overriding the default parameters:
 
 ```shell
-python examples/train/train_bcql.py --task OfflineCarCirvle-v0 --param1 args1 ...
+python examples/train/train_bcql.py --task OfflineCarCircle-v0 --param1 args1 ...
 ```
 By default, the config file and the logs during training will be written to `logs\` folder and the training plots can be viewed online using Wandb.
 
@@ -90,8 +90,8 @@ You can also launch a sequence of experiments or in parallel via the [EasyRunner
 
 ### Evaluation
 To evaluate a trained agent, for example, a BCQ agent, simply run
-```
-python example/eval/eval_bcql.py --path path_to_model --eval_episodes 20
+```shell
+python examples/eval/eval_bcql.py --path path_to_model --eval_episodes 20
 ```
 It will load config file from `path_to_model/config.yaml` and model file from `path_to_model/checkpoints/model.pt`, run 20 episodes, and print the average normalized reward and cost. The pretrained checkpoints for all datasets are available [here](https://drive.google.com/drive/folders/1lZmw2NVNR4YGUdrkih9o3rTMDrWCI_jw?usp=sharing) for reference.
 

--- a/examples/eval/eval_bc.py
+++ b/examples/eval/eval_bc.py
@@ -2,7 +2,6 @@ from dataclasses import asdict, dataclass
 from typing import Any, DefaultDict, Dict, List, Optional, Tuple
 
 import dsrl
-import gymnasium as gym  # noqa
 import numpy as np
 import pyrallis
 import torch
@@ -33,6 +32,9 @@ def eval(args: EvalConfig):
 
     if "Metadrive" in cfg["task"]:
         import gym
+    else:
+        import gymnasium as gym  # noqa
+
     env = gym.make(cfg["task"])
     env.set_target_cost(cfg["cost_limit"])
 

--- a/examples/eval/eval_bcql.py
+++ b/examples/eval/eval_bcql.py
@@ -2,7 +2,6 @@ from dataclasses import asdict, dataclass
 from typing import Any, DefaultDict, Dict, List, Optional, Tuple
 
 import dsrl
-import gymnasium as gym  # noqa
 import numpy as np
 import pyrallis
 import torch
@@ -33,6 +32,9 @@ def eval(args: EvalConfig):
 
     if "Metadrive" in cfg["task"]:
         import gym
+    else:
+        import gymnasium as gym  # noqa
+
     env = wrap_env(
         env=gym.make(cfg["task"]),
         reward_scale=cfg["reward_scale"],

--- a/examples/eval/eval_bearl.py
+++ b/examples/eval/eval_bearl.py
@@ -2,7 +2,6 @@ from dataclasses import asdict, dataclass
 from typing import Any, DefaultDict, Dict, List, Optional, Tuple
 
 import dsrl
-import gymnasium as gym  # noqa
 import numpy as np
 import pyrallis
 import torch
@@ -33,6 +32,9 @@ def eval(args: EvalConfig):
 
     if "Metadrive" in cfg["task"]:
         import gym
+    else:
+        import gymnasium as gym  # noqa
+
     env = wrap_env(
         env=gym.make(cfg["task"]),
         reward_scale=cfg["reward_scale"],

--- a/examples/eval/eval_cdt.py
+++ b/examples/eval/eval_cdt.py
@@ -2,7 +2,6 @@ from dataclasses import asdict, dataclass
 from typing import Any, DefaultDict, Dict, List, Optional, Tuple
 
 import dsrl
-import gymnasium as gym  # noqa
 import numpy as np
 import pyrallis
 import torch
@@ -35,6 +34,9 @@ def eval(args: EvalConfig):
 
     if "Metadrive" in cfg["task"]:
         import gym
+    else:
+        import gymnasium as gym  # noqa
+
     env = wrap_env(
         env=gym.make(cfg["task"]),
         reward_scale=cfg["reward_scale"],

--- a/examples/eval/eval_coptidice.py
+++ b/examples/eval/eval_coptidice.py
@@ -2,7 +2,6 @@ from dataclasses import asdict, dataclass
 from typing import Any, DefaultDict, Dict, List, Optional, Tuple
 
 import dsrl
-import gymnasium as gym  # noqa
 import numpy as np
 import pyrallis
 import torch
@@ -33,6 +32,9 @@ def eval(args: EvalConfig):
 
     if "Metadrive" in cfg["task"]:
         import gym
+    else:
+        import gymnasium as gym  # noqa
+
     env = wrap_env(
         env=gym.make(cfg["task"]),
         reward_scale=cfg["reward_scale"],

--- a/examples/eval/eval_cpq.py
+++ b/examples/eval/eval_cpq.py
@@ -2,7 +2,6 @@ from dataclasses import asdict, dataclass
 from typing import Any, DefaultDict, Dict, List, Optional, Tuple
 
 import dsrl
-import gymnasium as gym  # noqa
 import numpy as np
 import pyrallis
 import torch
@@ -33,6 +32,9 @@ def eval(args: EvalConfig):
 
     if "Metadrive" in cfg["task"]:
         import gym
+    else:
+        import gymnasium as gym  # noqa
+
     env = wrap_env(
         env=gym.make(cfg["task"]),
         reward_scale=cfg["reward_scale"],


### PR DESCRIPTION
Hello, I am well interested in offline rl problems. Recently I am implementing my own research idea, and I discovered your wonderful repo, and it really helps me a lot.

However, when I run the code, I found some typos of the running commands in the README.md. Also, in `eval()` function in the evaluation scripts, it seems that the local import of gym might overwrite the outer gymnasium import. This can make the python interpreter think `gym`  module is not assigned even if I am not using the Metadrive tasks. The error message is pasted below.

```
load config from OfflineCarCircle-v0-cost-10/CDT_seed20-3554/config.yaml
load model from OfflineCarCircle-v0-cost-10/CDT_seed20-3554/checkpoint/model.pt
Traceback (most recent call last):
  File "examples/eval/eval_cdt.py", line 103, in <module>
    eval()
  File "anaconda3/envs/OSRL/lib/python3.8/site-packages/pyrallis/argparsing.py", line 158, in wrapper_inner
    response = fn(cfg, *args, **kwargs)
  File "examples/eval/eval_cdt.py", line 42, in eval
    env=gym.make(cfg["task"]),
UnboundLocalError: local variable 'gym' referenced before assignment
```

I create the PR to fix the issue. The importing error might be my configuration error, and I wonder if it also happens in your side. 

Thank you for your time for checking this issue!
